### PR TITLE
Fixed issue with wrong link for SPM in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,9 +80,6 @@ Swift Package Manager:
 source 'https://github.com/kantarsifo/SifoInternet_IOS_SDK.git'
 ``` 
 
-1. Set branch to spm-package
-2. Import TSAnalyticsSwift library
-
 **2. Initialize the framework**
 
 ``` SWIFT

--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ Minimum iOS deployment target: 9.0
 
 Swift Package Manager:
 ``` Ruby
-source 'https://github.com/shortcut/sifo-mobileanalyticssdk-ios.git'
+source 'https://github.com/kantarsifo/SifoInternet_IOS_SDK.git'
 ``` 
 
 1. Set branch to spm-package


### PR DESCRIPTION
The link in the description for SPM was pointing to the Shortcut fork of this repo, witch is private. This fixes this and points it to this repo instead.